### PR TITLE
Basic notary server implementation

### DIFF
--- a/cmd/apostille/config.go
+++ b/cmd/apostille/config.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/coreos-inc/apostille/server"
+	"github.com/docker/distribution/health"
+	_ "github.com/docker/distribution/registry/auth/htpasswd"
+	_ "github.com/docker/distribution/registry/auth/token"
+	"github.com/docker/go-connections/tlsconfig"
+	"github.com/docker/notary"
+	"github.com/docker/notary/server/storage"
+	"github.com/docker/notary/signer/client"
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/signed"
+	"github.com/docker/notary/utils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/spf13/viper"
+	"golang.org/x/net/context"
+)
+
+const (
+	envPrefix = "APOSTILLE"
+)
+
+// getRequiredGunPrevixes returns the required gun prefixes accepted by this server
+func getRequiredGunPrefixes(configuration *viper.Viper) ([]string, error) {
+	prefixes := configuration.GetStringSlice("repositories.gun_prefixes")
+	for _, prefix := range prefixes {
+		// Check that GUN prefixes are in the correct format
+		p := path.Clean(strings.TrimSpace(prefix))
+		if p+"/" != prefix || strings.HasPrefix(p, "/") || strings.HasPrefix(p, "..") {
+			return nil, fmt.Errorf("invalid GUN prefix %s", prefix)
+		}
+	}
+	return prefixes, nil
+}
+
+// getAddrAndTLSConfig gets the address for the HTTP server, and parses the optional TLS
+// configuration for the server - if no TLS configuration is specified,
+// TLS is not enabled.
+func getAddrAndTLSConfig(configuration *viper.Viper) (string, *tls.Config, error) {
+	httpAddr := configuration.GetString("server.http_addr")
+	if httpAddr == "" {
+		return "", nil, fmt.Errorf("http listen address required for server")
+	}
+
+	tlsConfig, err := utils.ParseServerTLS(configuration, false)
+	if err != nil {
+		return "", nil, fmt.Errorf(err.Error())
+	}
+	return httpAddr, tlsConfig, nil
+}
+
+// grpcTLS sets up TLS for the GRPC connection to notary-signer
+func grpcTLS(configuration *viper.Viper) (*tls.Config, error) {
+	rootCA := utils.GetPathRelativeToConfig(configuration, "trust_service.tls_ca_file")
+	clientCert := utils.GetPathRelativeToConfig(configuration, "trust_service.tls_client_cert")
+	clientKey := utils.GetPathRelativeToConfig(configuration, "trust_service.tls_client_key")
+
+	if clientCert == "" && clientKey != "" || clientCert != "" && clientKey == "" {
+		return nil, fmt.Errorf("either pass both client key and cert, or neither")
+	}
+
+	tlsConfig, err := tlsconfig.Client(tlsconfig.Options{
+		CAFile:   rootCA,
+		CertFile: clientCert,
+		KeyFile:  clientKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Unable to configure TLS to the trust service: %s", err.Error())
+	}
+	return tlsConfig, nil
+}
+
+// getStore parses the configuration and returns a backing store for the TUF files
+func getStore(configuration *viper.Viper, hRegister healthRegister) (
+	storage.MetaStore, error) {
+	var store storage.MetaStore
+	backend := configuration.GetString("storage.backend")
+	logrus.Infof("Using %s backend", backend)
+
+	switch backend {
+	case notary.MemoryBackend:
+		return storage.NewMemStorage(), nil
+
+	case notary.MySQLBackend, notary.SQLiteBackend:
+		storeConfig, err := utils.ParseSQLStorage(configuration)
+		if err != nil {
+			return nil, err
+		}
+		s, err := storage.NewSQLStorage(storeConfig.Backend, storeConfig.Source)
+		if err != nil {
+			return nil, fmt.Errorf("Error starting %s driver: %s", backend, err.Error())
+		}
+		store = *storage.NewTUFMetaStorage(s)
+		hRegister("DB operational", time.Minute, s.CheckHealth)
+
+	default:
+		return nil, fmt.Errorf("%s is not a supported storage backend", backend)
+	}
+	return store, nil
+}
+
+type signerFactory func(hostname, port string, tlsConfig *tls.Config) (*client.NotarySigner, error)
+type healthRegister func(name string, duration time.Duration, check health.CheckFunc)
+
+// getNotarySigner returns a grpc connection to the notary-signer server
+func getNotarySigner(hostname, port string, tlsConfig *tls.Config) (*client.NotarySigner, error) {
+	conn, err := client.NewGRPCConnection(hostname, port, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewNotarySigner(conn), nil
+}
+
+// getTrustService parses the configuration and determines which trust service and
+// key algorithm to return
+func getTrustService(configuration *viper.Viper, sFactory signerFactory,
+	hRegister healthRegister) (signed.CryptoService, string, error) {
+
+	switch configuration.GetString("trust_service.type") {
+	case "local":
+		logrus.Info("Using local signing service, which requires ED25519. " +
+			"Ignoring all other trust_service parameters, including keyAlgorithm")
+		return signed.NewEd25519(), data.ED25519Key, nil
+
+	case "remote":
+		// continue with remote configuration below
+
+	default:
+		return nil, "", fmt.Errorf(
+			`must specify either a "local" or "remote" type for trust_service`)
+	}
+
+	clientTLS, err := grpcTLS(configuration)
+	if err != nil {
+		return nil, "", err
+	}
+
+	logrus.Info("Using remote signing service")
+
+	notarySigner, err := sFactory(
+		configuration.GetString("trust_service.hostname"),
+		configuration.GetString("trust_service.port"),
+		clientTLS,
+	)
+
+	if err != nil {
+		return nil, "", err
+	}
+
+	minute := 1 * time.Minute
+	hRegister(
+		"Trust operational",
+		// If the trust service fails, the server is degraded but not
+		// exactly unhealthy, so always return healthy and just log an
+		// error.
+		minute,
+		func() error {
+			err := notarySigner.CheckHealth(minute)
+			if err != nil {
+				logrus.Error("Trust not fully operational: ", err.Error())
+			}
+			return nil
+		},
+	)
+	return notarySigner, data.ED25519Key, nil
+}
+
+// getCacheConfig parses the cache configurations for GET-ting current and checksummed metadata,
+// returning the configuration for current (non-content-addressed) metadata
+// first, then the configuration for consistent (content-addressed) metadata
+// second. The configuration consists mainly of the max-age (an integer in seconds,
+// just like in the Cache-Control header) for each type of metadata.
+// The max-age must be between 0 and 31536000 (one year in seconds, which is
+// the recommended maximum time data is cached), else parsing will return an error.
+// A max-age of 0 will disable caching for that type of download (consistent or current).
+func getCacheConfig(configuration *viper.Viper) (current, consistent utils.CacheControlConfig, err error) {
+	cccs := make(map[string]utils.CacheControlConfig)
+	currentOpt, consistentOpt := "current_metadata", "consistent_metadata"
+
+	defaults := map[string]int{
+		currentOpt:    int(notary.CurrentMetadataCacheMaxAge.Seconds()),
+		consistentOpt: int(notary.ConsistentMetadataCacheMaxAge.Seconds()),
+	}
+	maxMaxAge := int(notary.CacheMaxAgeLimit.Seconds())
+
+	for optionName, seconds := range defaults {
+		m := configuration.GetString(fmt.Sprintf("caching.max_age.%s", optionName))
+		if m != "" {
+			seconds, err = strconv.Atoi(m)
+			if err != nil || seconds < 0 || seconds > maxMaxAge {
+				return nil, nil, fmt.Errorf(
+					"must specify a cache-control max-age between 0 and %v", maxMaxAge)
+			}
+		}
+		cccs[optionName] = utils.NewCacheControlConfig(seconds, optionName == currentOpt)
+	}
+	current = cccs[currentOpt]
+	consistent = cccs[consistentOpt]
+	return
+}
+
+// parseServerConfig parses the config file into a Config struct
+func parseServerConfig(configFilePath string) (context.Context, server.Config, error) {
+	config := viper.New()
+	utils.SetupViper(config, envPrefix)
+
+	// parse viper config
+	if err := utils.ParseViper(config, configFilePath); err != nil {
+		return nil, server.Config{}, err
+	}
+
+	ctx := context.Background()
+
+	// default is error level
+	lvl, err := utils.ParseLogLevel(config, logrus.ErrorLevel)
+	if err != nil {
+		return nil, server.Config{}, err
+	}
+	logrus.SetLevel(lvl)
+
+	prefixes, err := getRequiredGunPrefixes(config)
+	if err != nil {
+		return nil, server.Config{}, err
+	}
+
+	trust, keyAlgo, err := getTrustService(config, getNotarySigner, health.RegisterPeriodicFunc)
+	if err != nil {
+		return nil, server.Config{}, err
+	}
+	ctx = context.WithValue(ctx, "keyAlgorithm", keyAlgo)
+
+	store, err := getStore(config, health.RegisterPeriodicFunc)
+	if err != nil {
+		return nil, server.Config{}, err
+	}
+	ctx = context.WithValue(ctx, "metaStore", store)
+
+	currentCache, consistentCache, err := getCacheConfig(config)
+	if err != nil {
+		return nil, server.Config{}, err
+	}
+
+	httpAddr, tlsConfig, err := getAddrAndTLSConfig(config)
+	if err != nil {
+		return nil, server.Config{}, err
+	}
+
+	return ctx, server.Config{
+		Addr:                         httpAddr,
+		TLSConfig:                    tlsConfig,
+		Trust:                        trust,
+		AuthMethod:                   config.GetString("auth.type"),
+		AuthOpts:                     config.Get("auth.options"),
+		RepoPrefixes:                 prefixes,
+		CurrentCacheControlConfig:    currentCache,
+		ConsistentCacheControlConfig: consistentCache,
+	}, nil
+}

--- a/cmd/apostille/main.go
+++ b/cmd/apostille/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/coreos-inc/apostille/server"
+)
+
+type cmdFlags struct {
+	configFile string
+}
+
+func setupFlags(flagStorage *cmdFlags) {
+	flag.StringVar(&flagStorage.configFile, "config", "", "Path to configuration file")
+	flag.Usage = usage
+}
+
+func main() {
+	flagStorage := cmdFlags{}
+	setupFlags(&flagStorage)
+
+	flag.Parse()
+
+	ctx, serverConfig, err := parseServerConfig(flagStorage.configFile)
+	if err != nil {
+		logrus.Fatal(err.Error())
+	}
+
+	err = server.Run(ctx, serverConfig)
+
+	if err != nil {
+		logrus.Fatal(err.Error())
+	}
+	return
+}
+
+func usage() {
+	fmt.Println("usage:", os.Args[0])
+	flag.PrintDefaults()
+}

--- a/cmd/apostille/main_test.go
+++ b/cmd/apostille/main_test.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/distribution/health"
+	"github.com/docker/notary"
+	"github.com/docker/notary/server/storage"
+	"github.com/docker/notary/signer/client"
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/signed"
+	"github.com/docker/notary/utils"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	Cert = "../../fixtures/notary-server.crt"
+	Key  = "../../fixtures/notary-server.key"
+	Root = "../../fixtures/root-ca.crt"
+)
+
+// initializes a viper object with test configuration
+func configure(jsonConfig string) *viper.Viper {
+	config := viper.New()
+	config.SetConfigType("json")
+	config.ReadConfig(bytes.NewBuffer([]byte(jsonConfig)))
+	return config
+}
+
+func TestGetAddrAndTLSConfigInvalidTLS(t *testing.T) {
+	invalids := []string{
+		`{"server": {
+				"http_addr": ":1234",
+				"tls_key_file": "nope"
+		}}`,
+	}
+	for _, configJSON := range invalids {
+		_, _, err := getAddrAndTLSConfig(configure(configJSON))
+		require.Error(t, err)
+	}
+}
+
+func TestGetAddrAndTLSConfigNoHTTPAddr(t *testing.T) {
+	_, _, err := getAddrAndTLSConfig(configure(fmt.Sprintf(`{
+		"server": {
+			"tls_cert_file": "%s",
+			"tls_key_file": "%s"
+		}
+	}`, Cert, Key)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "http listen address required for server")
+}
+
+func TestGetAddrAndTLSConfigSuccessWithTLS(t *testing.T) {
+	httpAddr, tlsConf, err := getAddrAndTLSConfig(configure(fmt.Sprintf(`{
+		"server": {
+			"http_addr": ":2345",
+			"tls_cert_file": "%s",
+			"tls_key_file": "%s"
+		}
+	}`, Cert, Key)))
+	require.NoError(t, err)
+	require.Equal(t, ":2345", httpAddr)
+	require.NotNil(t, tlsConf)
+}
+
+func TestGetAddrAndTLSConfigSuccessWithoutTLS(t *testing.T) {
+	httpAddr, tlsConf, err := getAddrAndTLSConfig(configure(
+		`{"server": {"http_addr": ":2345"}}`))
+	require.NoError(t, err)
+	require.Equal(t, ":2345", httpAddr)
+	require.Nil(t, tlsConf)
+}
+
+func TestGetAddrAndTLSConfigWithClientTLS(t *testing.T) {
+	httpAddr, tlsConf, err := getAddrAndTLSConfig(configure(fmt.Sprintf(`{
+		"server": {
+			"http_addr": ":2345",
+			"tls_cert_file": "%s",
+			"tls_key_file": "%s",
+			"client_ca_file": "%s"
+		}
+	}`, Cert, Key, Root)))
+	require.NoError(t, err)
+	require.Equal(t, ":2345", httpAddr)
+	require.NotNil(t, tlsConf.ClientCAs)
+}
+
+func fakeRegisterer(callCount *int) healthRegister {
+	return func(_ string, _ time.Duration, _ health.CheckFunc) {
+		(*callCount)++
+	}
+
+}
+
+// If neither "remote" nor "local" is passed for "trust_service.type", an
+// error is returned.
+func TestGetInvalidTrustService(t *testing.T) {
+	invalids := []string{
+		`{"trust_service": {"type": "bruhaha", "key_algorithm": "rsa"}}`,
+		`{}`,
+	}
+	var registerCalled = 0
+
+	for _, config := range invalids {
+		_, _, err := getTrustService(configure(config),
+			getNotarySigner, fakeRegisterer(&registerCalled))
+		require.Error(t, err)
+		require.Contains(t, err.Error(),
+			"must specify either a \"local\" or \"remote\" type for trust_service")
+	}
+	// no health function ever registered
+	require.Equal(t, 0, registerCalled)
+}
+
+// If a local trust service is specified, a local trust service will be used
+// with an ED22519 algorithm no matter what algorithm was specified.  No health
+// function is configured.
+func TestGetLocalTrustService(t *testing.T) {
+	localConfig := `{"trust_service": {"type": "local", "key_algorithm": "meh"}}`
+
+	var registerCalled = 0
+
+	trust, algo, err := getTrustService(configure(localConfig),
+		getNotarySigner, fakeRegisterer(&registerCalled))
+	require.NoError(t, err)
+	require.IsType(t, &signed.Ed25519{}, trust)
+	require.Equal(t, data.ED25519Key, algo)
+
+	// no health function ever registered
+	require.Equal(t, 0, registerCalled)
+}
+
+// Invalid key algorithms result in an error if a remote trust service was
+// specified.
+func TestGetTrustServiceInvalidKeyAlgorithm(t *testing.T) {
+	configTemplate := `
+	{
+		"trust_service": {
+			"type": "remote",
+			"hostname": "blah",
+			"port": "1234",
+			"key_algorithm": "%s"
+		}
+	}`
+	badKeyAlgos := []string{
+		fmt.Sprintf(configTemplate, ""),
+		fmt.Sprintf(configTemplate, data.ECDSAx509Key),
+		fmt.Sprintf(configTemplate, "random"),
+	}
+	var registerCalled = 0
+
+	for _, config := range badKeyAlgos {
+		_, _, err := getTrustService(configure(config),
+			getNotarySigner, fakeRegisterer(&registerCalled))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid key algorithm")
+	}
+	// no health function ever registered
+	require.Equal(t, 0, registerCalled)
+}
+
+// template to be used for testing TLS parsing with the trust service
+var trustTLSConfigTemplate = `
+	{
+		"trust_service": {
+			"type": "remote",
+			"hostname": "notary-signer",
+			"port": "1234",
+			"key_algorithm": "ecdsa",
+			%s
+		}
+	}`
+
+// Client cert and Key either both have to be empty or both have to be
+// provided.
+func TestGetTrustServiceTLSMissingCertOrKey(t *testing.T) {
+	configs := []string{
+		fmt.Sprintf(`"tls_client_cert": "%s"`, Cert),
+		fmt.Sprintf(`"tls_client_key": "%s"`, Key),
+	}
+	var registerCalled = 0
+
+	for _, clientTLSConfig := range configs {
+		jsonConfig := fmt.Sprintf(trustTLSConfigTemplate, clientTLSConfig)
+		config := configure(jsonConfig)
+		_, _, err := getTrustService(config, getNotarySigner,
+			fakeRegisterer(&registerCalled))
+		require.Error(t, err)
+		require.True(t,
+			strings.Contains(err.Error(), "either pass both client key and cert, or neither"))
+	}
+	// no health function ever registered
+	require.Equal(t, 0, registerCalled)
+}
+
+// If no TLS configuration is provided for the host server, no TLS config will
+// be set for the trust service.
+func TestGetTrustServiceNoTLSConfig(t *testing.T) {
+	config := `{
+		"trust_service": {
+			"type": "remote",
+			"hostname": "notary-signer",
+			"port": "1234",
+			"key_algorithm": "ecdsa"
+		}
+	}`
+	var registerCalled = 0
+
+	var tlsConfig *tls.Config
+	var fakeNewSigner = func(_, _ string, c *tls.Config) (*client.NotarySigner, error) {
+		tlsConfig = c
+		return &client.NotarySigner{}, nil
+	}
+
+	trust, algo, err := getTrustService(configure(config),
+		fakeNewSigner, fakeRegisterer(&registerCalled))
+	require.NoError(t, err)
+	require.IsType(t, &client.NotarySigner{}, trust)
+	require.Equal(t, "ecdsa", algo)
+	require.Nil(t, tlsConfig.RootCAs)
+	require.Nil(t, tlsConfig.Certificates)
+	// health function registered
+	require.Equal(t, 1, registerCalled)
+}
+
+// The rest of the functionality of getTrustService depends upon
+// utils.ConfigureClientTLS, so this test just asserts that if successful,
+// the correct tls.Config is returned based on all the configuration parameters
+func TestGetTrustServiceTLSSuccess(t *testing.T) {
+	keypair, err := tls.LoadX509KeyPair(Cert, Key)
+	require.NoError(t, err, "Unable to load cert and key for testing")
+
+	tlspart := fmt.Sprintf(`"tls_client_cert": "%s", "tls_client_key": "%s"`,
+		Cert, Key)
+
+	var registerCalled = 0
+
+	var tlsConfig *tls.Config
+	var fakeNewSigner = func(_, _ string, c *tls.Config) (*client.NotarySigner, error) {
+		tlsConfig = c
+		return &client.NotarySigner{}, nil
+	}
+
+	trust, algo, err := getTrustService(
+		configure(fmt.Sprintf(trustTLSConfigTemplate, tlspart)),
+		fakeNewSigner, fakeRegisterer(&registerCalled))
+	require.NoError(t, err)
+	require.IsType(t, &client.NotarySigner{}, trust)
+	require.Equal(t, "ecdsa", algo)
+	require.Len(t, tlsConfig.Certificates, 1)
+	require.True(t, reflect.DeepEqual(keypair, tlsConfig.Certificates[0]))
+	// health function registered
+	require.Equal(t, 1, registerCalled)
+}
+
+// The rest of the functionality of getTrustService depends upon
+// utils.ConfigureServerTLS, so this test just asserts that if it fails,
+// the error is propagated.
+func TestGetTrustServiceTLSFailure(t *testing.T) {
+	tlspart := fmt.Sprintf(`"tls_client_cert": "none", "tls_client_key": "%s"`,
+		Key)
+
+	var registerCalled = 0
+
+	_, _, err := getTrustService(
+		configure(fmt.Sprintf(trustTLSConfigTemplate, tlspart)),
+		getNotarySigner, fakeRegisterer(&registerCalled))
+
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(),
+		"Unable to configure TLS to the trust service"))
+
+	// no health function ever registered
+	require.Equal(t, 0, registerCalled)
+}
+
+// Just to ensure that errors are propagated
+func TestGetStoreInvalid(t *testing.T) {
+	config := `{"storage": {"backend": "asdf", "db_url": "doesnt_matter_what_value_this_is"}}`
+
+	var registerCalled = 0
+
+	_, err := getStore(configure(config), fakeRegisterer(&registerCalled), false)
+	require.Error(t, err)
+
+	// no health function ever registered
+	require.Equal(t, 0, registerCalled)
+}
+
+func TestGetStoreDBStore(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "sqlite3")
+	require.NoError(t, err)
+	tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
+
+	config := fmt.Sprintf(`{"storage": {"backend": "%s", "db_url": "%s"}}`,
+		notary.SQLiteBackend, tmpFile.Name())
+
+	var registerCalled = 0
+
+	store, err := getStore(configure(config), fakeRegisterer(&registerCalled), false)
+	require.NoError(t, err)
+	_, ok := store.(storage.TUFMetaStorage)
+	require.True(t, ok)
+
+	// health function registered
+	require.Equal(t, 1, registerCalled)
+}
+
+func TestGetStoreRethinkDBStoreConnectionFails(t *testing.T) {
+	config := fmt.Sprintf(
+		`{"storage": {
+			"backend": "%s",
+			"db_url": "host:port",
+			"tls_ca_file": "/tls/ca.pem",
+			"client_cert_file": "/tls/cert.pem",
+			"client_key_file": "/tls/key.pem",
+			"database": "rethinkdbtest"
+			}
+		}`,
+		notary.RethinkDBBackend)
+
+	var registerCalled = 0
+
+	_, err := getStore(configure(config), fakeRegisterer(&registerCalled), false)
+	require.Error(t, err)
+}
+
+func TestGetMemoryStore(t *testing.T) {
+	var registerCalled = 0
+
+	config := fmt.Sprintf(`{"storage": {"backend": "%s"}}`, notary.MemoryBackend)
+	store, err := getStore(configure(config), fakeRegisterer(&registerCalled), false)
+	require.NoError(t, err)
+	_, ok := store.(*storage.MemStorage)
+	require.True(t, ok)
+
+	// no health function ever registered
+	require.Equal(t, 0, registerCalled)
+}
+
+func TestGetCacheConfig(t *testing.T) {
+	defaults := `{}`
+	valid := `{"caching": {"max_age": {"current_metadata": 0, "consistent_metadata": 31536000}}}`
+	invalids := []string{
+		`{"caching": {"max_age": {"current_metadata": 0, "consistent_metadata": 31539000}}}`,
+		`{"caching": {"max_age": {"current_metadata": -1, "consistent_metadata": 300}}}`,
+		`{"caching": {"max_age": {"current_metadata": "hello", "consistent_metadata": 300}}}`,
+	}
+
+	current, consistent, err := getCacheConfig(configure(defaults))
+	require.NoError(t, err)
+	require.Equal(t,
+		utils.PublicCacheControl{MaxAgeInSeconds: int(notary.CurrentMetadataCacheMaxAge.Seconds()),
+			MustReValidate: true}, current)
+	require.Equal(t,
+		utils.PublicCacheControl{MaxAgeInSeconds: int(notary.ConsistentMetadataCacheMaxAge.Seconds())}, consistent)
+
+	current, consistent, err = getCacheConfig(configure(valid))
+	require.NoError(t, err)
+	require.Equal(t, utils.NoCacheControl{}, current)
+	require.Equal(t, utils.PublicCacheControl{MaxAgeInSeconds: 31536000}, consistent)
+
+	for _, invalid := range invalids {
+		_, _, err := getCacheConfig(configure(invalid))
+		require.Error(t, err)
+	}
+}
+
+func TestGetGUNPRefixes(t *testing.T) {
+	valids := map[string][]string{
+		`{}`: nil,
+		`{"repositories": {"gun_prefixes": []}}`:         nil,
+		`{"repositories": {}}`:                           nil,
+		`{"repositories": {"gun_prefixes": ["hello/"]}}`: {"hello/"},
+	}
+	invalids := []string{
+		`{"repositories": {"gun_prefixes": " / "}}`,
+		`{"repositories": {"gun_prefixes": "nope"}}`,
+		`{"repositories": {"gun_prefixes": ["nope"]}}`,
+		`{"repositories": {"gun_prefixes": ["/nope/"]}}`,
+		`{"repositories": {"gun_prefixes": ["../nope/"]}}`,
+	}
+
+	for valid, expected := range valids {
+		prefixes, err := getRequiredGunPrefixes(configure(valid))
+		require.NoError(t, err)
+		require.Equal(t, expected, prefixes)
+	}
+	for _, invalid := range invalids {
+		_, err := getRequiredGunPrefixes(configure(invalid))
+		require.Error(t, err, "expected error with %s", invalid)
+	}
+}
+
+// For sanity, make sure we can always parse the sample config
+func TestSampleConfig(t *testing.T) {
+	var registerCalled = 0
+	_, _, err := parseServerConfig("../../fixtures/server-config.json", fakeRegisterer(&registerCalled), false)
+	require.NoError(t, err)
+
+	// once for the DB, once for the trust service
+	require.Equal(t, registerCalled, 2)
+}

--- a/fixtures/config.json
+++ b/fixtures/config.json
@@ -1,0 +1,14 @@
+{
+	"server": {
+		"http_addr": ":4443"
+	},
+	"trust_service": {
+	  "type": "local"
+	},
+	"logging": {
+		"level": "debug"
+	},
+	"storage": {
+		"backend": "memory"
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,192 @@
+package server
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/health"
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/docker/distribution/registry/auth"
+	"github.com/docker/notary"
+	"github.com/docker/notary/server/errors"
+	"github.com/docker/notary/server/handlers"
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/signed"
+	"github.com/docker/notary/utils"
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/net/context"
+)
+
+func init() {
+	data.SetDefaultExpiryTimes(notary.NotaryDefaultExpiries)
+}
+
+func prometheusOpts(operation string) prometheus.SummaryOpts {
+	return prometheus.SummaryOpts{
+		Namespace:   "apostille",
+		Subsystem:   "http",
+		ConstLabels: prometheus.Labels{"operation": operation},
+	}
+}
+
+// Config tells Run how to configure a server
+type Config struct {
+	Addr                         string
+	TLSConfig                    *tls.Config
+	Trust                        signed.CryptoService
+	AuthMethod                   string
+	AuthOpts                     interface{}
+	RepoPrefixes                 []string
+	ConsistentCacheControlConfig utils.CacheControlConfig
+	CurrentCacheControlConfig    utils.CacheControlConfig
+}
+
+// Run sets up and starts a TLS server that can be cancelled using the
+// given configuration. The context it is passed is the context it should
+// use directly for the TLS server, and generate children off for requests
+func Run(ctx context.Context, conf Config) error {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", conf.Addr)
+	if err != nil {
+		return err
+	}
+	var lsnr net.Listener
+	lsnr, err = net.ListenTCP("tcp", tcpAddr)
+	if err != nil {
+		return err
+	}
+
+	if conf.TLSConfig != nil {
+		logrus.Info("Enabling TLS")
+		lsnr = tls.NewListener(lsnr, conf.TLSConfig)
+	}
+
+	var ac auth.AccessController
+	if conf.AuthMethod == "token" {
+		authOptions, ok := conf.AuthOpts.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("auth.options must be a map[string]interface{}")
+		}
+		ac, err = auth.GetAccessController(conf.AuthMethod, authOptions)
+		if err != nil {
+			return err
+		}
+	}
+	svr := http.Server{
+		Addr: conf.Addr,
+		Handler: RootHandler(
+			ac, ctx, conf.Trust,
+			conf.ConsistentCacheControlConfig, conf.CurrentCacheControlConfig,
+			conf.RepoPrefixes),
+	}
+	logrus.Info("Starting on ", conf.Addr)
+	err = svr.Serve(lsnr)
+	return err
+}
+
+// filterImagePrefixes checks that incoming requests only work on the defined GUN prefixes
+func filterImagePrefixes(requiredPrefixes []string, err error, handler http.Handler) http.Handler {
+	if len(requiredPrefixes) == 0 {
+		return handler
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		imageName := mux.Vars(r)["imageName"]
+
+		for _, prefix := range requiredPrefixes {
+			if strings.HasPrefix(imageName, prefix) {
+				handler.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		errcode.ServeJSON(w, err)
+	})
+}
+
+type serverEndpoint struct {
+	OperationName       string
+	ServerHandler       utils.ContextHandler
+	ErrorIfGUNInvalid   error
+	IncludeCacheHeaders bool
+	CacheControlConfig  utils.CacheControlConfig
+	PermissionsRequired []string
+}
+
+// RootHandler returns the handler that routes all the paths from / for the
+// server.
+func RootHandler(ac auth.AccessController, ctx context.Context, trust signed.CryptoService,
+	consistent, current utils.CacheControlConfig, repoPrefixes []string) http.Handler {
+
+	authWrapper := utils.RootHandlerFactory(ac, ctx, trust)
+
+	createHandler := func(opts serverEndpoint) http.Handler {
+		var wrapped http.Handler
+		wrapped = authWrapper(opts.ServerHandler, opts.PermissionsRequired...)
+		if opts.IncludeCacheHeaders {
+			wrapped = utils.WrapWithCacheHandler(opts.CacheControlConfig, wrapped)
+		}
+		wrapped = filterImagePrefixes(repoPrefixes, opts.ErrorIfGUNInvalid, wrapped)
+		return prometheus.InstrumentHandlerWithOpts(prometheusOpts(opts.OperationName), wrapped)
+	}
+
+	invalidGUNErr := errors.ErrInvalidGUN.WithDetail(fmt.Sprintf("Require GUNs with prefix: %v", repoPrefixes))
+	notFoundError := errors.ErrMetadataNotFound.WithDetail(nil)
+
+	r := mux.NewRouter()
+	r.Methods("GET").Path("/v2/").Handler(authWrapper(handlers.MainHandler))
+
+	r.Methods("POST").Path("/v2/{imageName:.*}/_trust/tuf/").Handler(createHandler(serverEndpoint{
+		OperationName:       "UpdateTUF",
+		ErrorIfGUNInvalid:   invalidGUNErr,
+		ServerHandler:       handlers.AtomicUpdateHandler,
+		PermissionsRequired: []string{"push", "pull"},
+	}))
+	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.{checksum:[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128}}.json").Handler(createHandler(serverEndpoint{
+		OperationName:       "GetRoleByHash",
+		ErrorIfGUNInvalid:   notFoundError,
+		IncludeCacheHeaders: true,
+		CacheControlConfig:  consistent,
+		ServerHandler:       handlers.GetHandler,
+		PermissionsRequired: []string{"pull"},
+	}))
+	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.json").Handler(createHandler(serverEndpoint{
+		OperationName:       "GetRole",
+		ErrorIfGUNInvalid:   notFoundError,
+		IncludeCacheHeaders: true,
+		CacheControlConfig:  current,
+		ServerHandler:       handlers.GetHandler,
+		PermissionsRequired: []string{"pull"},
+	}))
+	r.Methods("GET").Path(
+		"/v2/{imageName:.*}/_trust/tuf/{tufRole:snapshot|timestamp}.key").Handler(createHandler(serverEndpoint{
+		OperationName:       "GetKey",
+		ErrorIfGUNInvalid:   notFoundError,
+		ServerHandler:       handlers.GetKeyHandler,
+		PermissionsRequired: []string{"push", "pull"},
+	}))
+	r.Methods("POST").Path(
+		"/v2/{imageName:.*}/_trust/tuf/{tufRole:snapshot|timestamp}.key").Handler(createHandler(serverEndpoint{
+		OperationName:       "RotateKey",
+		ErrorIfGUNInvalid:   notFoundError,
+		ServerHandler:       handlers.RotateKeyHandler,
+		PermissionsRequired: []string{"*"},
+	}))
+	r.Methods("DELETE").Path("/v2/{imageName:.*}/_trust/tuf/").Handler(createHandler(serverEndpoint{
+		OperationName:       "DeleteTUF",
+		ErrorIfGUNInvalid:   notFoundError,
+		ServerHandler:       handlers.DeleteHandler,
+		PermissionsRequired: []string{"*"},
+	}))
+
+	r.Methods("GET").Path("/_notary_server/health").HandlerFunc(health.StatusHandler)
+	r.Methods("GET").Path("/metrics").Handler(prometheus.Handler())
+	r.Methods("GET", "POST", "PUT", "HEAD", "DELETE").Path("/{other:.*}").Handler(
+		authWrapper(handlers.NotFoundHandler))
+
+	return r
+}


### PR DESCRIPTION
`cmd/apostille` is essentially a stripped down `cmd/notary-server` from notary; likewise `server/server.go` is essentially a stripped down `server/server.go` from notary.

The main integration point will be in the Handler for `POST` requests, where we'll do our own additional processing before handing off to the standard notary client.

The hope here is that we're able to take advantage of improvements to notary without needing to buy-in entirely.