### PR TITLE
Trust multiplexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ Apostille acts similarly to a [notary server](https://github.com/docker/notary) 
 ```bash
 glide install
 # required: see https://github.com/mattfarina/golang-broken-vendor
-rm -rf vendor/github.com/docker/notary/vendor
+rm -rf vendor/github.com/docker/distribution/vendor   
+rm -rf vendor/github.com/docker/notary/vendor                                                                
 go build ./cmd/apostille/
 ./apostille --config=fixtures/config.json
 ```
+
+Note: updating dependencies may require pinning proto/grpc to the versions used in Notary.

--- a/auth/accesscontroller.go
+++ b/auth/accesscontroller.go
@@ -1,0 +1,207 @@
+package auth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/context"
+	registryAuth "github.com/docker/distribution/registry/auth"
+	registryToken "github.com/docker/distribution/registry/auth/token"
+	"github.com/docker/libtrust"
+)
+
+// keyserverAccessController implements the auth.AccessController interface.
+type keyserverAccessController struct {
+	realm     string
+	issuer    string
+	service   string
+	keyserver string
+}
+
+// tokenAccessOptions is a convenience type for handling
+// options to the contstructor of a keyserverAccessController.
+type tokenAccessOptions struct {
+	realm     string
+	issuer    string
+	service   string
+	keyserver string
+}
+
+// checkOptions gathers the necessary options
+// for a keyserverAccessController from the given map.
+func checkOptions(options map[string]interface{}) (tokenAccessOptions, error) {
+	var opts tokenAccessOptions
+
+	keys := []string{"realm", "issuer", "service", "keyserver"}
+	vals := make([]string, 0, len(keys))
+	for _, key := range keys {
+		val, ok := options[key].(string)
+		if !ok {
+			return opts, fmt.Errorf("quay token auth requires a valid option string: %q", key)
+		}
+		vals = append(vals, val)
+	}
+
+	opts.realm, opts.issuer, opts.service, opts.keyserver = vals[0], vals[1], vals[2], vals[3]
+
+	return opts, nil
+}
+
+// NewKeyserverAccessController creates an keyserverAccessController using the given options.
+func NewKeyserverAccessController(options map[string]interface{}) (registryAuth.AccessController, error) {
+	config, err := checkOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	return &keyserverAccessController{
+		realm:     config.realm,
+		issuer:    config.issuer,
+		service:   config.service,
+		keyserver: config.keyserver,
+	}, nil
+}
+
+// Authorized handles checking whether the given request is authorized
+// for actions on resources described by the given access items.
+func (ac *keyserverAccessController) Authorized(ctx context.Context, accessItems ...registryAuth.Access) (context.Context, error) {
+	challenge := &authChallenge{
+		realm:     ac.realm,
+		service:   ac.service,
+		accessSet: newAccessSet(accessItems...),
+	}
+
+	req, err := context.GetRequest(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	parts := strings.Split(req.Header.Get("Authorization"), " ")
+
+	if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+		challenge.err = registryToken.ErrTokenRequired
+		return nil, challenge
+	}
+
+	rawToken := parts[1]
+
+	token, err := registryToken.NewToken(rawToken)
+	if err != nil {
+		challenge.err = err
+		return nil, challenge
+	}
+
+	url := fmt.Sprintf("%s/services/%s/keys/%s", ac.keyserver, ac.service, token.Header.KeyID)
+	logrus.Infof("fetching jwk from keyserver: %s", url)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		challenge.err = err
+		return nil, challenge
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		challenge.err = err
+		return nil, challenge
+	}
+
+	// parse into pubKey
+	pubKey, err := libtrust.UnmarshalPublicKeyJWK(body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode JWK value: %s", err)
+	}
+	if err = VerifyNonX509(token, ac.issuer, ac.service, pubKey); err != nil {
+		challenge.err = err
+		return nil, challenge
+	}
+
+	accessSet := AccessSet(token)
+	for _, access := range accessItems {
+		if !accessSet.contains(access) {
+			challenge.err = registryToken.ErrInsufficientScope
+			return nil, challenge
+		}
+	}
+
+	return registryAuth.WithUser(ctx, registryAuth.UserInfo{Name: token.Claims.Subject}), nil
+}
+
+// VerifyNonX509 attempts to verify this token using the given options.
+// Returns a nil error if the token is valid.
+// Unlike standard Token verification, does not expect a cert chain.
+func VerifyNonX509(token *registryToken.Token, issuer, service string, signingKey libtrust.PublicKey) error {
+	// Verify that the Issuer claim is a trusted authority.
+	if issuer != token.Claims.Issuer {
+		logrus.Infof("token from untrusted issuer: %q", token.Claims.Issuer)
+		return registryToken.ErrInvalidToken
+	}
+
+	// Verify that the Audience claim is allowed.
+	if service != token.Claims.Audience {
+		logrus.Infof("token intended for another audience: %q", token.Claims.Audience)
+		return registryToken.ErrInvalidToken
+	}
+
+	// Verify that the token is currently usable and not expired.
+	currentTime := time.Now()
+
+	ExpWithLeeway := time.Unix(token.Claims.Expiration, 0).Add(Leeway)
+	if currentTime.After(ExpWithLeeway) {
+		logrus.Infof("token not to be used after %s - currently %s", ExpWithLeeway, currentTime)
+		return registryToken.ErrInvalidToken
+	}
+
+	NotBeforeWithLeeway := time.Unix(token.Claims.NotBefore, 0).Add(-Leeway)
+	if currentTime.Before(NotBeforeWithLeeway) {
+		logrus.Infof("token not to be used before %s - currently %s", NotBeforeWithLeeway, currentTime)
+		return registryToken.ErrInvalidToken
+	}
+
+	// Verify the token signature.
+	if len(token.Signature) == 0 {
+		logrus.Info("token has no signature")
+		return registryToken.ErrInvalidToken
+	}
+
+	// Finally, verify the signature of the token using the key which signed it.
+	if err := signingKey.Verify(strings.NewReader(token.Raw), token.Header.SigningAlg, token.Signature); err != nil {
+		logrus.Infof("unable to verify token signature: %s", err)
+		return registryToken.ErrInvalidToken
+	}
+
+	return nil
+}
+
+// AccessSet returns a set of actions available for the resource
+// actions listed in the `access` section of the token.
+func AccessSet(token *registryToken.Token) accessSet {
+	if token.Claims == nil {
+		return nil
+	}
+
+	accessSet := make(accessSet, len(token.Claims.Access))
+
+	for _, resourceActions := range token.Claims.Access {
+		resource := registryAuth.Resource{
+			Type: resourceActions.Type,
+			Name: resourceActions.Name,
+		}
+
+		set, exists := accessSet[resource]
+		if !exists {
+			set = newActionSet()
+			accessSet[resource] = set
+		}
+
+		for _, action := range resourceActions.Actions {
+			set.add(action)
+		}
+	}
+
+	return accessSet
+}

--- a/auth/vendored.go
+++ b/auth/vendored.go
@@ -1,0 +1,168 @@
+package auth
+
+// This file contains vendored code from docker/distribution
+// Vendoring is necessary because these objects/methods are private
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	registryAuth "github.com/docker/distribution/registry/auth"
+	registryToken "github.com/docker/distribution/registry/auth/token"
+)
+
+// Leeway is the Duration that will be added to NBF and EXP claim
+// checks to account for clock skew as per https://tools.ietf.org/html/rfc7519#section-4.1.5
+const Leeway = 60 * time.Second
+
+// stringSet is vendored from docker distribution
+// https://github.com/docker/distribution/blob/b6e0cfbdaa1ddc3a17c95142c7bf6e42c5567370/registry/auth/token/stringset.go
+type stringSet map[string]struct{}
+
+// NewStringSet creates a new StringSet with the given strings.
+func newStringSet(keys ...string) stringSet {
+	ss := make(stringSet, len(keys))
+	ss.add(keys...)
+	return ss
+}
+
+// Add inserts the given keys into this StringSet.
+func (ss stringSet) add(keys ...string) {
+	for _, key := range keys {
+		ss[key] = struct{}{}
+	}
+}
+
+// Contains returns whether the given key is in this StringSet.
+func (ss stringSet) contains(key string) bool {
+	_, ok := ss[key]
+	return ok
+}
+
+// Keys returns a slice of all keys in this StringSet.
+func (ss stringSet) keys() []string {
+	keys := make([]string, 0, len(ss))
+
+	for key := range ss {
+		keys = append(keys, key)
+	}
+
+	return keys
+}
+
+// actionSet is a special type of stringSet also vendored from docker/distribution
+// https://github.com/docker/distribution/blob/b6e0cfbdaa1ddc3a17c95142c7bf6e42c5567370/registry/auth/token/util.go
+type actionSet struct {
+	stringSet
+}
+
+func newActionSet(actions ...string) actionSet {
+	return actionSet{newStringSet(actions...)}
+}
+
+// Contains calls StringSet.Contains() for
+// either "*" or the given action string.
+func (s actionSet) contains(action string) bool {
+	return s.stringSet.contains("*") || s.stringSet.contains(action)
+}
+
+// accessSet maps a typed, named resource to
+// a set of actions requested or authorized.
+// vendored from docker/distribution
+// https://github.com/docker/distribution/blob/a6bf3dd064f15598166bca2d66a9962a9555139e/registry/auth/token/accesscontroller.go
+type accessSet map[registryAuth.Resource]actionSet
+
+// newAccessSet constructs an accessSet from
+// a variable number of registryAuth.Access items.
+func newAccessSet(accessItems ...registryAuth.Access) accessSet {
+	accessSet := make(accessSet, len(accessItems))
+
+	for _, access := range accessItems {
+		resource := registryAuth.Resource{
+			Type: access.Type,
+			Name: access.Name,
+		}
+
+		set, exists := accessSet[resource]
+		if !exists {
+			set = newActionSet()
+			accessSet[resource] = set
+		}
+
+		set.add(access.Action)
+	}
+
+	return accessSet
+}
+
+// contains returns whether or not the given access is in this accessSet.
+func (s accessSet) contains(access registryAuth.Access) bool {
+	actionSet, ok := s[access.Resource]
+	if ok {
+		return actionSet.contains(access.Action)
+	}
+
+	return false
+}
+
+// scopeParam returns a collection of scopes which can
+// be used for a WWW-Authenticate challenge parameter.
+// See https://tools.ietf.org/html/rfc6750#section-3
+func (s accessSet) scopeParam() string {
+	scopes := make([]string, 0, len(s))
+
+	for resource, actionSet := range s {
+		actions := strings.Join(actionSet.keys(), ",")
+		scopes = append(scopes, fmt.Sprintf("%s:%s:%s", resource.Type, resource.Name, actions))
+	}
+
+	return strings.Join(scopes, " ")
+}
+
+// authChallenge implements the auth.Challenge interface.
+// https://github.com/docker/distribution/blob/a6bf3dd064f15598166bca2d66a9962a9555139e/registry/auth/token/accesscontroller.go
+type authChallenge struct {
+	err       error
+	realm     string
+	service   string
+	accessSet accessSet
+}
+
+var _ registryAuth.Challenge = authChallenge{}
+
+// Error returns the internal error string for this authChallenge.
+func (ac authChallenge) Error() string {
+	return ac.err.Error()
+}
+
+// Status returns the HTTP Response Status Code for this authChallenge.
+func (ac authChallenge) Status() int {
+	return http.StatusUnauthorized
+}
+
+// challengeParams constructs the value to be used in
+// the WWW-Authenticate response challenge header.
+// See https://tools.ietf.org/html/rfc6750#section-3
+func (ac authChallenge) challengeParams() string {
+	str := fmt.Sprintf("Bearer realm=%q,service=%q", ac.realm, ac.service)
+
+	if scope := ac.accessSet.scopeParam(); scope != "" {
+		str = fmt.Sprintf("%s,scope=%q", str, scope)
+	}
+
+	if ac.err == registryToken.ErrInvalidToken || ac.err == registryToken.ErrMalformedToken {
+		str = fmt.Sprintf("%s,error=%q", str, "invalid_token")
+	} else if ac.err == registryToken.ErrInsufficientScope {
+		str = fmt.Sprintf("%s,error=%q", str, "insufficient_scope")
+	}
+	logrus.Info(str)
+	return str
+}
+
+// SetChallenge sets the WWW-Authenticate value for the response.
+func (ac authChallenge) SetHeaders(w http.ResponseWriter) {
+	w.Header().Add("WWW-Authenticate", ac.challengeParams())
+}

--- a/cmd/apostille/config.go
+++ b/cmd/apostille/config.go
@@ -166,7 +166,7 @@ func getTrustService(configuration *viper.Viper, sFactory signerFactory,
 		// error.
 		minute,
 		func() error {
-			err := notarySigner.CheckHealth(minute)
+			err := notarySigner.CheckHealth(minute, "trust")
 			if err != nil {
 				logrus.Error("Trust not fully operational: ", err.Error())
 			}
@@ -238,13 +238,13 @@ func parseServerConfig(configFilePath string) (context.Context, server.Config, e
 	if err != nil {
 		return nil, server.Config{}, err
 	}
-	ctx = context.WithValue(ctx, "keyAlgorithm", keyAlgo)
+	ctx = context.WithValue(ctx, notary.CtxKeyKeyAlgo, keyAlgo)
 
 	store, err := getStore(config, health.RegisterPeriodicFunc)
 	if err != nil {
 		return nil, server.Config{}, err
 	}
-	ctx = context.WithValue(ctx, "metaStore", store)
+	ctx = context.WithValue(ctx, notary.CtxKeyMetaStore, store)
 
 	currentCache, consistentCache, err := getCacheConfig(config)
 	if err != nil {

--- a/fixtures/config.json
+++ b/fixtures/config.json
@@ -10,5 +10,14 @@
 	},
 	"storage": {
 		"backend": "memory"
-	}
+	},
+	"auth": {
+		"type": "quaytoken",
+		"options": {
+			"realm": "https://quay.io",
+			"service": "apostille",
+			"issuer": "quay",
+			"keyserver": "https://quay.io"
+		}
+    }
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,28 +1,18 @@
-hash: 1dac40e6054521e62f08448a9e219737e37fafdbe1e3329ed52daa45ff1315f2
-updated: 2016-10-31T11:16:22.325598112-04:00
+hash: b21b2b9d988fd3dc53e58854caceaecda9b79110e3d62d340d2b27ae3278e90a
+updated: 2016-11-15T10:50:46.01587413-05:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
   subpackages:
   - edwards25519
-- name: github.com/Azure/go-ansiterm
-  version: 388960b655244e76e24c75f48631564eaefade62
-  subpackages:
-  - winterm
 - name: github.com/beorn7/perks
   version: b965b613227fddccbfffe13eae360ed3fa822f8d
   subpackages:
   - quantile
 - name: github.com/bugsnag/bugsnag-go
-  version: 13fd6b8acda029830ef9904df6b63be0a83369d0
+  version: b1d153021fcd90ca3f080db36bec96dc690fb274
   subpackages:
   - errors
-  - examples/appengine
-  - examples/http
-  - examples/revelapp/app
-  - examples/revelapp/app/controllers
-  - examples/revelapp/tests
-  - revel
 - name: github.com/bugsnag/osext
   version: 0dd3f918b21bec95ace9dc86c7e70266cfc5c702
 - name: github.com/bugsnag/panicwrap
@@ -36,57 +26,28 @@ imports:
 - name: github.com/cenkalti/backoff
   version: 4dc77674aceaabba2c7e3da25d4c823edfb73f99
 - name: github.com/docker/distribution
-  version: 12acdf0a6c1e56d965ac6eb395d2bce687bf22fc
+  version: e249b61e900df4d36779a690971e5cab691a4954
   subpackages:
   - context
-  - digest
   - health
-  - reference
   - registry/api/errcode
-  - registry/api/v2
   - registry/auth
   - registry/auth/htpasswd
-  - registry/auth/silly
   - registry/auth/token
-  - registry/client
-  - registry/client/auth
-  - registry/client/transport
-  - registry/storage/cache
-  - registry/storage/cache/memory
   - uuid
-  - vendor/github.com/Sirupsen/logrus
-  - vendor/github.com/docker/libtrust
-  - vendor/github.com/gorilla/context
-  - vendor/github.com/gorilla/mux
-  - vendor/golang.org/x/crypto/bcrypt
-  - vendor/golang.org/x/crypto/blowfish
-  - vendor/golang.org/x/net/context
-- name: github.com/docker/docker
-  version: 91853e44aeb20e55bcfcad5041c274783fdc06bc
-  subpackages:
-  - pkg/system
-  - pkg/term
-  - pkg/term/windows
 - name: github.com/docker/go
   version: d30aec9fd63c35133f8f79c3412ad91a3b08be06
   subpackages:
   - canonical/json
 - name: github.com/docker/go-connections
-  version: f549a9393d05688dff0992ef3efd8bbe6c628aeb
+  version: 990a1a1a70b0da4c4cb70e117971a4f0babfbf1a
   subpackages:
   - tlsconfig
 - name: github.com/docker/libtrust
-  version: 9cbd2a1374f46905c68a4eb3694a130610adc62a
-  subpackages:
-  - testutil
-  - tlsdemo
-  - trustgraph
+  version: fa567046d9b14f6aa788882a950d69651d230b21
 - name: github.com/docker/notary
-  version: c8aa8cf53cbcda2e92def0c9291e25d770493494
+  version: 3657629fb191cdb741cefee80e9872c0dcac2feb
   subpackages:
-  - cmd/notary-server
-  - cryptoservice
-  - passphrase
   - proto
   - server
   - server/errors
@@ -102,23 +63,19 @@ imports:
   - tuf
   - tuf/data
   - tuf/signed
-  - tuf/testutils
   - tuf/utils
   - tuf/validation
   - utils
-  - version
 - name: github.com/go-sql-driver/mysql
-  version: 0cc29e9fe8e25c2c58cf47bcab566e029bbaa88b
+  version: a732e14c62dde3285440047bba97581bc472ae18
 - name: github.com/golang/protobuf
   version: c3cefd437628a0b7d31b34fe44b3a7a540e98527
   subpackages:
   - proto
-  - proto/proto3_proto
-  - ptypes/any
 - name: github.com/gorilla/context
   version: 14f550f51af52180c2eefed15e5fd18d63c0a64a
 - name: github.com/gorilla/mux
-  version: e444e69cbd2e2e3e0749a2f3c717cec491552bbf
+  version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/jinzhu/gorm
@@ -142,7 +99,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/mitchellh/mapstructure
-  version: 2caf8efc93669b6c43e0441cdc6aed17546c96f3
+  version: 482a9fd5fa83e8c4e7817413b80f3eb8feec03ef
 - name: github.com/prometheus/client_golang
   version: 449ccefff16c8e2b7229f6be1921ba22f62461fe
   subpackages:
@@ -162,49 +119,29 @@ imports:
 - name: github.com/Shopify/logrus-bugsnag
   version: 5a46080c635f13e8b60c24765c19d62e1ca8d0fb
 - name: github.com/Sirupsen/logrus
-  version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
+  version: d26492970760ca5d33129d2d799e34be5c4782eb
 - name: github.com/spf13/cast
   version: 4d07383ffe94b5e5a6fa3af9211374a4507a0184
 - name: github.com/spf13/jwalterweatherman
   version: 3d60171a64319ef63c78bd45bd60e6eab1e75f8b
 - name: github.com/spf13/pflag
-  version: cb88ea77998c3f024757528e3305022ab50b43be
+  version: 5644820622454e71517561946e3d94b9f9db6842
 - name: github.com/spf13/viper
   version: be5ff3e4840cf692388bde7a057595a474ef379e
-  subpackages:
-  - remote
-- name: github.com/stretchr/testify
-  version: 089c7181b8c728499929ff09b62d3fdd8df8adff
-  subpackages:
-  - assert
-  - require
 - name: golang.org/x/crypto
-  version: 5bcd134fee4dd1475da17714aac19c0aa0142e2f
+  version: c10c31b5e94b6f7a0283272dc2bb27163dcea24b
   subpackages:
   - bcrypt
   - blowfish
-  - cast5
-  - md4
-  - nacl/secretbox
-  - openpgp
-  - openpgp/armor
-  - openpgp/elgamal
-  - openpgp/errors
-  - openpgp/packet
-  - openpgp/s2k
+  - ocsp
   - pbkdf2
-  - poly1305
-  - salsa20/salsa
-  - scrypt
-  - ssh/terminal
 - name: golang.org/x/net
-  version: 6a513affb38dc9788b449d59ffed099b8de18fa0
+  version: 4876518f9e71663000c348837735820161a42df7
   subpackages:
   - context
   - http2
   - http2/hpack
   - internal/timeseries
-  - lex/httplex
   - trace
 - name: golang.org/x/sys
   version: 442cd600860ce722f6615730eb008a37a87b13ee
@@ -213,34 +150,14 @@ imports:
 - name: google.golang.org/grpc
   version: 452f01f3ae159dcec83bbf0c6b0d96860e07b5e6
   subpackages:
-  - benchmark
-  - benchmark/client
-  - benchmark/grpc_testing
-  - benchmark/server
-  - benchmark/stats
   - codes
   - credentials
-  - credentials/oauth
-  - examples/helloworld/greeter_client
-  - examples/helloworld/greeter_server
-  - examples/helloworld/helloworld
-  - examples/route_guide/client
-  - examples/route_guide/routeguide
-  - examples/route_guide/server
   - grpclog
-  - grpclog/glogger
-  - health
   - health/grpc_health_v1
   - internal
-  - interop
-  - interop/client
-  - interop/grpc_testing
-  - interop/server
   - metadata
   - naming
   - peer
-  - test/codec_perf
-  - test/grpc_testing
   - transport
 - name: gopkg.in/dancannon/gorethink.v2
   version: 3742792da4bc279ccd6d807f24687009cbeda860
@@ -253,5 +170,18 @@ imports:
 - name: gopkg.in/yaml.v2
   version: bef53efd0c76e49e6de55ead051f886bea7e9420
 testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
 - name: github.com/mattn/go-sqlite3
-  version: b4142c444a8941d0d92b0b7103a24df9cd815e42
+  version: ca5e3819723d8eeaf170ad510e7da1d6d2e94a08
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,9 +1,43 @@
 package: github.com/coreos-inc/apostille
 import:
-- package: github.com/docker/notary
-  version: ~0.4.2
+- package: github.com/Sirupsen/logrus
+  version: ^0.11.0
+- package: github.com/docker/distribution
+  version: ^2.6.0-rc.1
   subpackages:
-  - cmd/notary-server
+  - context
+  - health
+  - registry/auth
+  - registry/auth/htpasswd
+  - registry/auth/token
+- package: github.com/docker/go-connections
+  version: ^0.2.1
+  subpackages:
+  - tlsconfig
+- package: github.com/docker/libtrust
+- package: github.com/docker/notary
+  version: ^0.5.0
+  subpackages:
+  - server
+  - server/errors
+  - server/handlers
+  - server/storage
+  - signer/client
+  - tuf/data
+  - tuf/signed
+  - utils
+- package: github.com/go-sql-driver/mysql
+  version: ^1.2.0
+- package: github.com/gorilla/mux
+  version: ^1.1.0
+- package: github.com/spf13/viper
 - package: golang.org/x/net
   subpackages:
   - context
+testImport:
+- package: github.com/mattn/go-sqlite3
+  version: ^1.2.0
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - require

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,0 +1,28 @@
+FROM golang:1.7.3-alpine
+MAINTAINER Evan Cordell "cordell.evan@gmail.com"
+
+RUN apk add --update git gcc libc-dev ca-certificates && rm -rf /var/cache/apk/*
+
+# Install SQL DB migration tool
+RUN go get github.com/mattes/migrate
+
+ENV APOSTILLE_SRC github.com/coreos-inc/apostille
+
+# Copy the local repo to the expected go path
+COPY . /go/src/${APOSTILLE_SRC}
+
+WORKDIR /go/src/${APOSTILLE_SRC}
+
+ENV SERVICE_NAME=apostille
+EXPOSE 4443
+
+# Install notary-server
+RUN go install \
+    -ldflags "-w" \
+    ${APOSTILLE_SRC}/cmd/apostille && apk del git gcc libc-dev
+
+#ADD fixtures/root-ca.crt /usr/local/share/ca-certificates/root-ca.crt
+RUN update-ca-certificates
+
+ENTRYPOINT [ "apostille" ]
+CMD [ "-config=fixtures/config.json" ]

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -1,3 +1,4 @@
+// Package storage provides primitives for interacting with apostille db data
 package storage
 
 import (
@@ -6,9 +7,13 @@ import (
 	notaryStorage "github.com/docker/notary/server/storage"
 )
 
+// Username represents a username string
 type Username string
+
+// GUN represents a GUN string
 type GUN string
 
+// SignerMetaStore wraps a standard MetaStore and adds signing user information
 type SignerMetaStore interface {
 	notaryStorage.MetaStore
 	AddUserAsSigner(user Username, gun GUN)
@@ -16,17 +21,20 @@ type SignerMetaStore interface {
 	IsSigner(user Username, gun GUN) bool
 }
 
+// SignerKey used for hashing user/gun pair for map keys
 type SignerKey struct {
 	user Username
 	gun  GUN
 }
 
+// MemoryStore extends MemStorage to implement the SignerMetaStore interface
 type MemoryStore struct {
 	notaryStorage.MemStorage
 	lock    sync.Mutex
 	signers map[SignerKey]struct{}
 }
 
+// NewMemoryStore creates a new MemoryStore with a standard MemStorage and blank signers
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
 		MemStorage: *notaryStorage.NewMemStorage(),
@@ -34,18 +42,21 @@ func NewMemoryStore() *MemoryStore {
 	}
 }
 
+// AddUserAsSigner adds a user to the signing group for a GUN
 func (m *MemoryStore) AddUserAsSigner(user Username, gun GUN) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.signers[SignerKey{user, gun}] = struct{}{}
 }
 
+// RemoveUserAsSigner removes a user from the signing group for a GUN
 func (m *MemoryStore) RemoveUserAsSigner(user Username, gun GUN) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	delete(m.signers, SignerKey{user, gun})
 }
 
+// IsSigner returns whether or not a user is in the group of signers for a GUN
 func (m *MemoryStore) IsSigner(user Username, gun GUN) bool {
 	_, ok := m.signers[SignerKey{user, gun}]
 	return ok


### PR DESCRIPTION
This PR does two main things:

 - Trust multiplexing, i.e. serving different roots based on the requesting user. Really this is just the support work for that, since I'm still just serving the same root everywhere. The scaffolding is all there, though.

- Quay auth support. Had to add a new `keyserverAuthController` which handles talking to the keyserver to get a key to verify.

Things not yet addressed, but coming:

- tests
- caching keys from the keyserver so we don't request every time
- actual db/migration support, not just in-memory
- actually serving a different root based on whether the user is a signer or not