### PR TITLE
feat(auth): don't allow access if `$disabled` flag is sent

### DIFF
--- a/auth/keyserver_accesscontroller.go
+++ b/auth/keyserver_accesscontroller.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/context"
 	registryAuth "github.com/docker/distribution/registry/auth"
@@ -18,6 +20,7 @@ import (
 )
 
 const TufRootSigner string = "com.apostille.root"
+const TufDisabled string = "$disabled"
 
 // keyserverAccessController implements the auth.AccessController interface.
 type keyserverAccessController struct {
@@ -178,6 +181,11 @@ func (ac *keyserverAccessController) Authorized(ctx context.Context, accessItems
 			challenge.err = registryToken.ErrInsufficientScope
 			return nil, challenge
 		}
+	}
+
+	if tokenContext.Context.TufRootSigner == TufDisabled {
+		challenge.err = errors.New("trust not enabled for repo")
+		return nil, challenge
 	}
 
 	return context.WithValue(ctx, TufRootSigner, tokenContext.Context.TufRootSigner), nil


### PR DESCRIPTION
```
$ docker -D push quay.dev/devtable/test-27698:latest
The push refers to a repository [quay.dev/devtable/test-27698]
214f73fdd6b3: Pushed
latest: digest: sha256:e987d538ff585d9114070a05d11a964ccfe5c2750dfe6e6d4a37f35bad01d0b8 size: 1501
Signing and pushing trust metadata
DEBU[0036] reading certificate directory: /Users/evan/.docker/tls/quay.dev
DEBU[0036] No yubikey found, using alternative key storage: no library found
DEBU[0036] Increasing token expiration to: 60 seconds
DEBU[0036] received HTTP status 401 when requesting root.
you are not authorized to perform this operation: server returned 401.

$curl -H 'Authorization: Bearer 2UWVswUvimgWWeGzzEurvlPWemfw7sjLHlRMPWuW' -H 'Content-Type: application/json' -X POST -d '{"trust_enabled": true}' https://quay.dev/api/v1/repository/devtable/test-27698/c
hangetrust
{"success": true}

$ docker -D push quay.dev/devtable/test-27698:latest
The push refers to a repository [quay.dev/devtable/test-27698]
214f73fdd6b3: Layer already exists
latest: digest: sha256:e987d538ff585d9114070a05d11a964ccfe5c2750dfe6e6d4a37f35bad01d0b8 size: 1501
Signing and pushing trust metadata
DEBU[0018] reading certificate directory: /Users/evan/.docker/tls/quay.dev
DEBU[0018] No yubikey found, using alternative key storage: no library found
DEBU[0018] Increasing token expiration to: 60 seconds
DEBU[0018] received HTTP status 404 when requesting root.
...
```