### PR TITLE
fix(migrations): switch back to old migrate tool

### DIFF
--- a/migrations/migrate.sh
+++ b/migrations/migrate.sh
@@ -7,7 +7,7 @@ do
 		iter=0
 		MIGRATIONS_PATH=${MIGRATIONS_PATH:-migrations/mysql}
 		# have to poll for DB to come up
-		until migrate -path=$MIGRATIONS_PATH -database=$DATABASE up
+		until migrate -path=$MIGRATIONS_PATH -url=$DATABASE up
 		do
 			iter=$(( iter+1 ))
 			if [[ $iter -gt 30 ]]; then
@@ -17,4 +17,16 @@ do
 			echo "waiting for $DATABASE to come up."
 			sleep 1
 		done
+		pre=$(migrate -path=$MIGRATIONS_PATH -url="${DATABASE}" version)
+		if migrate -path=$MIGRATIONS_PATH -url="${DATABASE}" up ; then
+			post=$(migrate -path=$MIGRATIONS_PATH -url="${DATABASE}" version)
+			if [ "$pre" != "$post" ]; then
+				echo "apostille database ($DATABASE) migrated to latest version"
+			else
+				echo "apostille database ($DATABASE)) already at latest version"
+			fi
+		else
+			echo "apostille database ($DATABASE)) migration failed"
+			exit 1
+		fi
 done

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -21,7 +21,7 @@ RUN set -ex \
         make \
         curl \
 	\
-	&& go get github.com/wallester/migrate \
+	&& go get github.com/ecordell/migrate \
 	&& mv /go/bin/migrate /usr/bin/migrate \
 	&& mv /go/src/${APOSTILLE_SRC}/migrations /migrations \
 	&& mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" \

--- a/server.dev.Dockerfile
+++ b/server.dev.Dockerfile
@@ -3,8 +3,7 @@ MAINTAINER Evan Cordell "cordell.evan@gmail.com"
 
 RUN apk add --update curl git gcc libc-dev ca-certificates && rm -rf /var/cache/apk/*
 
-## Pin to the specific v3.0.0 version
-RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate 
+RUN go get github.com/ecordell/migrate 
 
 ENV APOSTILLE_SRC github.com/coreos-inc/apostille
 

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -2,8 +2,7 @@ FROM golang:1.7.3-alpine
 
 RUN apk add --update curl git openssh-client gcc libc-dev && rm -rf /var/cache/apk/*
 
-# Pin to the specific v3.0.0 version
-RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate
+RUN go get github.com/ecordell/migrate 
 RUN go get github.com/docker/notary/cmd/notary-signer
 
 


### PR DESCRIPTION
I took the old working migrate tool and forked it, updated all the paths, etc. Now everything should be back to normal.