### PR TITLE
fix(helm/apostille-app/templates): fix name collision

### DIFF
--- a/helm/apostille-app/templates/apostille-ingress-prometheus.yaml
+++ b/helm/apostille-app/templates/apostille-ingress-prometheus.yaml
@@ -1,7 +1,7 @@
 kind: Ingress
 apiVersion: extensions/v1beta1
 metadata:
-  name: {{.Values.service}}
+  name: {{.Values.service}}-ingress
   namespace: {{.Values.apostille_namespace}}
   annotations:
     kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
there was a name collision with the ingress controller

Issue: https://coreosdev.atlassian.net/browse/QUAY-608

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format